### PR TITLE
Fix/document windows installer process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 icon/
 dist/
+warp_journal.build/
+warp_journal.dist/
 
 # Only contain settings specific to tha local environment.
 poetry.toml

--- a/README.md
+++ b/README.md
@@ -58,6 +58,52 @@ If you're not dual-booting, you can still manually enter the history URL in Warp
 
 Mac OS is also supported, at least technically; I have no way to test this personally, but if you can, I'd love to hear if it's working :)
 
+### Windows Installation Process
+
+> **TODO: Make this work with poetry/pipx.**
+
+**Pre-requisites:**
+
+-   Python 3.9+ is installed:
+
+    ```psh
+    winget install -e --id Python.Python.3.9
+    ```
+
+-   nuitka is installed:
+
+    ```psh
+    python -m pip install -U nuitka
+    ```
+-   MSIS (Nullsoft Scriptable Install System) is installed.
+
+    ```psh
+    winget install -e --id NSIS.NSIS
+    ```
+-   Directly install the direct dependencies with Pip (not Pipx or in a virtualenv):
+
+    ```psh
+    pip install bottle gevent gevent-websocket
+    ```
+
+**Steps:**
+
+1.  Checkout the repository.
+
+2.  In the repository root directory, run:
+
+    ```
+    nuitka warp_journal
+    ```
+
+    This creates a usable `warp_journal.exe` executable in the `warp_journal.dist\` subfolder.
+
+3.  To create an installer in `dist\` that you can use: from the repository root directory, run:
+
+    ```
+    <path to NSIS>\makensis.exe warp-journal.nsi
+    ```
+
 ## Warp Journal uses
 
 - [Alpine.js](https://github.com/alpinejs/alpine) - [License](3rd-party-licenses/LICENSE_alpinejs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "warp-journal"
-version = "1.1.0"
+version = "1.2.0"
 description = "Honkai: Star Rail gacha tracker and analysis."
 authors = ["Ennea"]
 license = "MIT"

--- a/warp-journal.nsi
+++ b/warp-journal.nsi
@@ -2,7 +2,7 @@
 !define MUI_ICON "icon.ico"
 
 Name "Warp Journal"
-OutFile "warp-journal-1.0.1.exe"
+OutFile "dist\warp-journal-1.2.0.exe"
 Unicode True
 RequestExecutionLevel admin
 InstallDir "$PROGRAMFILES\Warp Journal"
@@ -30,21 +30,21 @@ Section "Warp Journal"
   SetOutPath $INSTDIR
 
   ; Kill Warp Journal if it's already running
-  nsExec::Exec 'taskkill /f /im warp-journal.exe'
+  nsExec::Exec 'taskkill /f /im warp_journal.exe'
 
   ; Files to install
-  File /r "warp-journal.dist\*.*"
+  File /r "warp_journal.dist\*.*"
 
   ; Write the installation path into the registry
   WriteRegStr HKLM "Software\WarpJournal" "InstallDir" "$INSTDIR"
 
   ; start menu shortcut
   CreateDirectory "$SMPROGRAMS\Warp Journal"
-  CreateShortcut "$SMPROGRAMS\Warp Journal\Warp Journal.lnk" "$INSTDIR\warp-journal.exe"
+  CreateShortcut "$SMPROGRAMS\Warp Journal\Warp Journal.lnk" "$INSTDIR\warp_journal.exe"
 
   ; Write the uninstall keys for Windows
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\WarpJournal" "DisplayName" "Warp Journal"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\WarpJournal" "DisplayIcon" '"$INSTDIR\warp-journal.exe"'
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\WarpJournal" "DisplayIcon" '"$INSTDIR\warp_journal.exe"'
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\WarpJournal" "UninstallString" '"$INSTDIR\uninstall.exe"'
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\WarpJournal" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\WarpJournal" "NoRepair" 1

--- a/warp_journal/__main__.py
+++ b/warp_journal/__main__.py
@@ -1,20 +1,20 @@
 # nuitka-project: --standalone
-# nuitka-project: --include-data-file=./icon.png=icon.png
-# nuitka-project: --include-data-dir=./frontend=frontend
+# nuitka-project: --include-data-file=warp_journal/frontend/icon.png=icon.png
+# nuitka-project: --include-data-dir=warp_journal/frontend=warp_journal/frontend
 # nuitka-project-if: {OS} in ('Windows'):
 #     nuitka-project: --mingw64
 #     nuitka-project: --plugin-enable=tk-inter
-#     nuitka-project: --windows-disable-console
-#     nuitka-project: --windows-icon-from-ico=./icon.ico
+#     nuitka-project: --windows-console-mode=disable
+#     nuitka-project: --windows-icon-from-ico=icon.ico
 #     nuitka-project: --windows-company-name=-
 #     nuitka-project: --windows-product-name=Warp Journal
 #     nuitka-project: --windows-file-description=Warp Journal
-#     nuitka-project: --windows-product-version=1.0.1
+#     nuitka-project: --windows-product-version=1.2.0
 
 import logging
 
-from .util import set_up_logging, get_usable_port
-from .server import Server
+from warp_journal.util import set_up_logging, get_usable_port
+from warp_journal.server import Server
 
 def main():
     set_up_logging()

--- a/warp_journal/client.py
+++ b/warp_journal/client.py
@@ -7,10 +7,10 @@ from time import sleep
 from urllib.error import URLError, HTTPError
 from urllib.request import urlopen
 
-from .enums import ItemType
-from .exceptions import EndpointError, RequestError, UnsupportedRegion
-from .database import Database
-from .url_util import GachaUrl
+from warp_journal.enums import ItemType
+from warp_journal.exceptions import EndpointError, RequestError, UnsupportedRegion
+from warp_journal.database import Database
+from warp_journal.url_util import GachaUrl
 
 
 class Client:

--- a/warp_journal/database.py
+++ b/warp_journal/database.py
@@ -2,8 +2,8 @@ import logging
 import sqlite3
 from shutil import copyfile
 
-from .util import get_data_path, panic
-from .enums import ItemType
+from warp_journal.util import get_data_path, panic
+from warp_journal.enums import ItemType
 
 
 # convert a bytestring stored in sqlite back to our enum

--- a/warp_journal/paths.py
+++ b/warp_journal/paths.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from .error import panic
+from warp_journal.error import panic
 
 def get_data_path() -> Path:
     if sys.platform == 'win32':

--- a/warp_journal/server.py
+++ b/warp_journal/server.py
@@ -11,14 +11,16 @@ from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
 from geventwebsocket import WebSocketError
 
-from . import url_util
-from .client import Client
-from .enums import ItemType
-from .exceptions import AuthTokenExtractionError, MissingAuthTokenError, LogNotFoundError, RequestError, EndpointError, UnsupportedRegion
+from warp_journal import url_util
+from warp_journal.client import Client
+from warp_journal.enums import ItemType
+from warp_journal.exceptions import AuthTokenExtractionError, MissingAuthTokenError, LogNotFoundError, RequestError, EndpointError, UnsupportedRegion
 
 
 class Server:
     def __init__(self, port):
+        logging.info('Serving %s', Path(__file__).parent)
+
         self._client = Client()
         self._app = bottle.Bottle()
         self._frontend_path = Path(__file__).parent / 'frontend'

--- a/warp_journal/url_util.py
+++ b/warp_journal/url_util.py
@@ -5,8 +5,8 @@ import re
 from typing import NamedTuple
 from urllib.parse import ParseResult, urlencode, urlparse, parse_qs
 
-from .paths import get_cache_path
-from .exceptions import AuthTokenExtractionError, LogNotFoundError
+from warp_journal.paths import get_cache_path
+from warp_journal.exceptions import AuthTokenExtractionError, LogNotFoundError
 
 __all__ = [
     'find_gacha_url',

--- a/warp_journal/util.py
+++ b/warp_journal/util.py
@@ -5,8 +5,8 @@ import sys
 from urllib.request import urlopen
 from urllib.error import URLError, HTTPError
 
-from .error import panic
-from .paths import get_data_path
+from warp_journal.error import panic
+from warp_journal.paths import get_data_path
 
 
 def set_up_logging():


### PR DESCRIPTION
Code changes to make the project compatible with Windows exe export again:

- nuitka doesn't like relative imports, use base module name `warp_journal`
- fix the output directory setup for nuitka data files when running the code as a module
- update README.md with usable Windows installation instructions

Should help with #13, but I don't know how the CI can be set up in this repository. For now, I left instructions.