### PR TITLE
Add support for collaboration banners

### DIFF
--- a/warp_journal/client.py
+++ b/warp_journal/client.py
@@ -49,7 +49,6 @@ class Client:
         if url.region != 'hkrpg_global':
             raise UnsupportedRegion('Unsupported region.')
 
-        url.parsed_url.params
         # Note: we will be modifying this in-place
         query_dict: dict[str, str] = {
             **url.query_dict,

--- a/warp_journal/client.py
+++ b/warp_journal/client.py
@@ -57,8 +57,13 @@ class Client:
             'lang': 'en',
         }
 
+        # Some banners use a different path
+        path_segments = url.parsed_url.path.split('/')
+        path_segments[-1] = self.get_last_path_segment(banner_type)
+        url_with_path = url._with_path('/'.join(path_segments))
+
         latest_warp_id = None
-        while result := self._request(url._with_query(query_dict)):
+        while result := self._request(url_with_path._with_query(query_dict)):
             if not result['list']:
                 break
             for warp in result['list']:
@@ -86,8 +91,18 @@ class Client:
             1: 'Stellar Warp',
             2: 'Departure Warp',
             11: 'Character Event Warp',
-            12: 'Light Cone Event Warp'
+            12: 'Light Cone Event Warp',
+            21: 'Character Collaboration Warp',
+            22: 'Light Cone Collaboration Warp',
         }
+
+    @staticmethod
+    def get_last_path_segment(banner_type: int) -> str:
+        match banner_type:
+            case 21 | 22:
+                return 'getLdGachaLog'
+            case _:
+                return 'getGachaLog'
 
     def fetch_and_store_warp_history(self, url: GachaUrl):
         logging.info('Fetching warp history')

--- a/warp_journal/server.py
+++ b/warp_journal/server.py
@@ -203,9 +203,11 @@ class Server:
 
     def _update_warp_history(self):
         body = cast(Optional[dict], bottle.request.json)
-        url = body.get('url') if body else None
+        provided_url = body.get('url') if body else None
         try:
-            if not url:
+            if provided_url:
+                url = GachaUrl.of(provided_url)
+            else:
                 url = url_util.find_gacha_url()
         except (AuthTokenExtractionError, LogNotFoundError) as e:
             bottle.response.status = 400

--- a/warp_journal/server.py
+++ b/warp_journal/server.py
@@ -15,6 +15,7 @@ from . import url_util
 from .client import Client
 from .enums import ItemType
 from .exceptions import AuthTokenExtractionError, MissingAuthTokenError, LogNotFoundError, RequestError, EndpointError, UnsupportedRegion
+from .url_util import GachaUrl
 
 
 class Server:

--- a/warp_journal/url_util.py
+++ b/warp_journal/url_util.py
@@ -43,6 +43,10 @@ class GachaUrl(NamedTuple):
         parsed_url = self.parsed_url._replace(query=urlencode(query_dict))
         return GachaUrl(parsed_url, query_dict)
 
+    def _with_path(self, path: str) -> GachaUrl:
+        parsed_url = self.parsed_url._replace(path=path)
+        return GachaUrl(parsed_url, self.query_dict)
+
 
 def find_gacha_url() -> GachaUrl:
     """Find the URL used to fetch gacha history.
@@ -59,7 +63,7 @@ def find_gacha_url() -> GachaUrl:
     with path.open('rb') as fp:
         cache_file = fp.read()
 
-    regex = re.compile(rb'https://[^\0]+/getGachaLog[^\0]*')
+    regex = re.compile(rb'https://[^\0]+/get(?:Ld)?GachaLog[^\0]*')
     matches = regex.findall(cache_file)
     if not matches:
         raise AuthTokenExtractionError('Could not find authentication token in the log file. Open the warp history in the game, then try again.')


### PR DESCRIPTION
In addition to the new banner types, they also use a different path, which we need to consider during parsing and when requesting the history for all banner types.