### PR TITLE
Strip `begin_id` query param that breaks pagination

### DIFF
--- a/warp_journal/client.py
+++ b/warp_journal/client.py
@@ -55,7 +55,12 @@ class Client:
             'gacha_type': str(banner_type),
             'size': '20',
             'lang': 'en',
+            'page': '1',
         }
+
+        # Ensure the begin_id parameter is not set
+        # because it breaks pagination.
+        query_dict.pop('begin_id', None)
 
         # Some banners use a different path
         path_segments = url.parsed_url.path.split('/')


### PR DESCRIPTION
This appears to have been added at some point?