### PR TITLE
Prevent line wrapping for banner type

### DIFF
--- a/warp_journal/frontend/index.html
+++ b/warp_journal/frontend/index.html
@@ -269,10 +269,10 @@
                         <template x-for="warp in pagedWarpHistory">
                             <tr :class="warp.rarity == 5 ? 'rarity-5' : warp.rarity == 4 ? 'rarity-4' : ''">
                                 <td><div x-text="warp.numOnBanner"></div></td>
-                                <td class="overflow align-left"><div x-text="warp.name"></div></td>
+                                <td class="overflow align-left" :title="warp.name"><div x-text="warp.name"></div></td>
                                 <td :class="warp.rarityText.length > 1 ? 'star' : ''"><div x-text="warp.rarityText"></div></td>
                                 <td><div x-text="warp.type"></div></td>
-                                <td><div x-text="warp.bannerTypeName"></div></td>
+                                <td class="overflow" :title="warp.bannerTypeName"><div x-text="warp.bannerTypeName"></div></td>
                                 <td><div x-text="warp.pity || '–'"></div></td>
                                 <td><div x-text="warp.time"></div></td>
                             </tr>


### PR DESCRIPTION
Also add title attributes for the columns with text-overflow: ellipsis.

Before:

<img width="1046" height="302" alt="image" src="https://github.com/user-attachments/assets/b8513526-c527-4069-b875-303d0bc138a4" />

After:

<img width="1060" height="302" alt="image" src="https://github.com/user-attachments/assets/f7b4efff-bc88-477c-8868-d5510ab6cae7" />
